### PR TITLE
Update to solc v0.6.10

### DIFF
--- a/contracts/Badges/Badges.sol
+++ b/contracts/Badges/Badges.sol
@@ -288,7 +288,7 @@ contract Badges is Ownable, AccessControl, ERC721Burnable, ERC721Holder {
     /// @dev _transfer() has been overriden
     /// @dev reverts on transferFrom() and safeTransferFrom()
     function _transfer(address from, address to, uint256 tokenId) internal override {
-      revert("ERC721: token transfer disabled");
+      require(false,"ERC721: token transfer disabled");
       super._transfer(from, to, tokenId);
     }
 

--- a/contracts/Badges/Badges.sol
+++ b/contracts/Badges/Badges.sol
@@ -1,5 +1,5 @@
 /// SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.6.9;
+pragma solidity 0.6.10;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721Burnable.sol";
 import "@openzeppelin/contracts/token/ERC721/ERC721Holder.sol";

--- a/contracts/Badges/Badges.sol
+++ b/contracts/Badges/Badges.sol
@@ -1,7 +1,6 @@
 /// SPDX-License-Identifier: BSD-3-Clause
 pragma solidity 0.6.8;
 
-import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/ERC721Burnable.sol";
 import "@openzeppelin/contracts/token/ERC721/ERC721Holder.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
@@ -102,7 +101,7 @@ contract Badges is Ownable, AccessControl, ERC721Burnable, ERC721Holder {
     return string(b);
   }
   */
-  // cloned form OpenZeppelin v2.5
+
   modifier onlyMinter() {
       require(isMinter(msg.sender), "Caller is not a minter");
       _;

--- a/contracts/Badges/Badges.sol
+++ b/contracts/Badges/Badges.sol
@@ -1,5 +1,5 @@
 /// SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.6.8;
+pragma solidity 0.6.9;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721Burnable.sol";
 import "@openzeppelin/contracts/token/ERC721/ERC721Holder.sol";
@@ -288,7 +288,7 @@ contract Badges is Ownable, AccessControl, ERC721Burnable, ERC721Holder {
     /// @dev _transfer() has been overriden
     /// @dev reverts on transferFrom() and safeTransferFrom()
     function _transfer(address from, address to, uint256 tokenId) internal override {
-      require(!true, "ERC721: token transfer disabled");
+      revert("ERC721: token transfer disabled");
       super._transfer(from, to, tokenId);
     }
 

--- a/contracts/Migrations/Migrations.sol
+++ b/contracts/Migrations/Migrations.sol
@@ -1,5 +1,5 @@
 /// SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.6.8;
+pragma solidity 0.6.9;
 
 contract Migrations {
   address public owner;

--- a/contracts/Migrations/Migrations.sol
+++ b/contracts/Migrations/Migrations.sol
@@ -1,5 +1,5 @@
 /// SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.6.9;
+pragma solidity 0.6.10;
 
 contract Migrations {
   address public owner;

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -87,7 +87,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-       version: "0.6.8",    // Fetch exact version from solc-bin (default: truffle's version)
+       version: "0.6.9",    // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       // settings: {          // See the solidity docs for advice about optimization and evmVersion
          optimizer: {

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -87,7 +87,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-       version: "0.6.9",    // Fetch exact version from solc-bin (default: truffle's version)
+       version: "0.6.10",    // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       // settings: {          // See the solidity docs for advice about optimization and evmVersion
          optimizer: {


### PR DESCRIPTION
Updated:
- solc to v0.6.10
- disabled _transfer() 
- Cleanup